### PR TITLE
Fix Elm version range

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -7,7 +7,7 @@
     "exposed-modules": [
         "Main"
     ],
-    "elm-version": "0.0.0 <= v < 1.0.0",
+    "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/browser": "1.0.0 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",


### PR DESCRIPTION
0.0.0 <= v < 1.0.0 is not a valid Elm version range. Unfortunately the compiler doesn't check for this so here's a manual fix.